### PR TITLE
properly handle TMPDIR

### DIFF
--- a/pkg.sh
+++ b/pkg.sh
@@ -17,7 +17,7 @@ wd=$(pwd)
 counter=0
 idir="./$3"
 self="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )/$(basename "$0")"
-tmpdir=$(mktemp -d "${TMPDIR:-/tmp/}$(basename $0).XXXXXXXXXXXX")
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/$(basename $0).XXXXXXXXXXXX")
 
 # mkurl generates a url from an import directive
 mkurl() {


### PR DESCRIPTION
If `TMPDIR` is set, it did not add the slash separating the tmp directory from the subdirectory name, so it tried to create a directory directly under `/`, resulting in e.g.:

```
mktemp: failed to create directory via template ‘/tmppkg.sh.XXXXXXXXXXXX’: Permission denied
```