### PR TITLE
Fix saving imports to a subdirectory

### DIFF
--- a/pkg.sh
+++ b/pkg.sh
@@ -149,7 +149,7 @@ import() {
                 # protect against directory traversal attacks
                 >&2 echo "line $ln: invalid output directory: $outdir"; exit 1
             fi
-            set -- "${@:0:i+1}"
+            set -- "${@:1:i}"
             break
         fi
         i=$(expr $i + 1)


### PR DESCRIPTION
Fix saving imports to a subdirectory -- the code seemed to be adding a spurious `pkg.sh` arg in `set`.

I waive all rights to the code and don't care about licensing issues here.